### PR TITLE
Result set show cost and duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The AWS Step Functions state machine accepts the following parameters:
 The AWS Step Functions state machine will return the following outputs:
 
 * **power**: the optimal power configuration
-* **cost**: the corresponding average cost (per invocation)
+* **stats**: the corresponding average cost and average duration(per invocation)
 
 
 ## State Machine Internals

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The AWS Step Functions state machine accepts the following parameters:
 The AWS Step Functions state machine will return the following outputs:
 
 * **power**: the optimal power configuration
-* **stats**: the corresponding average cost and average duration(per invocation)
-* **cost**: DEPRECATED: use stats instead
+* **cost**: the corresponding average cost (per invocation)
+* **duration**: the corresponding average duration (per invocation)
 
 
 ## State Machine Internals

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The AWS Step Functions state machine will return the following outputs:
 
 * **power**: the optimal power configuration
 * **stats**: the corresponding average cost and average duration(per invocation)
+* **cost**: DEPRECATED: the corresponding average cost(per invocation)
 
 
 ## State Machine Internals

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The AWS Step Functions state machine will return the following outputs:
 
 * **power**: the optimal power configuration
 * **stats**: the corresponding average cost and average duration(per invocation)
-* **cost**: DEPRECATED: the corresponding average cost(per invocation)
+* **cost**: DEPRECATED: use stats instead
 
 
 ## State Machine Internals

--- a/lambda/finalizer.js
+++ b/lambda/finalizer.js
@@ -10,24 +10,25 @@ module.exports.handler = (event, context, callback) => {
         callback(error);
         throw error;  // TODO useless?
     }
-  
+
     // clean up input event (too much data from previous steps)
-    const prices = event.map(function(p) {
+    const stats = event.map(function (p) {
         return {
             'power': p.value,
-            'cost': p.price
+            'stats': p.stats
         };
     });
 
     // sort by cost
-    prices.sort(function(p1, p2){
-        return p1.cost - p2.cost;}
+    stats.sort(function (p1, p2) {
+        return p1.stats.cost - p2.stats.cost;
+    }
     );
 
-    console.log(prices);  // logging is free, right?
+    console.log(stats);  // logging is free, right?
 
     // just return th first one
-    const cheapest = prices[0];
+    const cheapest = stats[0];
 
     // TODO check for same-cost configuration and improve selection?
 

--- a/lambda/finalizer.js
+++ b/lambda/finalizer.js
@@ -15,14 +15,14 @@ module.exports.handler = (event, context, callback) => {
     const stats = event.map(function (p) {
         return {
             'power': p.value,
-            'stats': p.stats,
-            'cost': p.stats.averagePrice // deprecated
+            'cost': p.stats.averagePrice,
+            'duration': p.stats.averageDuration
         };
     });
 
     // sort by cost
     stats.sort(function (p1, p2) {
-        return p1.stats.averagePrice - p2.stats.averagePrice;
+        return p1.cost - p2.cost;
     }
     );
 

--- a/lambda/finalizer.js
+++ b/lambda/finalizer.js
@@ -15,7 +15,8 @@ module.exports.handler = (event, context, callback) => {
     const stats = event.map(function (p) {
         return {
             'power': p.value,
-            'stats': p.stats
+            'stats': p.stats,
+            'cost': p.stats.averagePrice // deprecated
         };
     });
 

--- a/lambda/finalizer.js
+++ b/lambda/finalizer.js
@@ -21,7 +21,7 @@ module.exports.handler = (event, context, callback) => {
 
     // sort by cost
     stats.sort(function (p1, p2) {
-        return p1.stats.cost - p2.stats.cost;
+        return p1.stats.averagePrice - p2.stats.averagePrice;
     }
     );
 

--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -97,9 +97,9 @@ module.exports.invokeLambda = function (lambdaARN, alias, payload) {
 };
 
 /**
- * Compute average price, given a RAM value and an average duration.
+ * Compute average price and returns with average duration, given a RAM value and an average duration.
  */
-module.exports.computeAveragePrice = function (minCost, minRAM, value, averageDuration) {
+module.exports.computeStats = function (minCost, minRAM, value, averageDuration) {
     // console.log('avg duration: ', averageDuration);
     // compute official price per 100ms
     const pricePer100ms = value * minCost / minRAM;

--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -9,7 +9,7 @@ const utils = module.exports;
 module.exports.checkLambdaAlias = function (lambdaARN, alias) {
     // console.log('Checking alias ', alias);
     const params = {
-        FunctionName: lambdaARN, 
+        FunctionName: lambdaARN,
         Name: alias,
     };
     const lambda = new AWS.Lambda();
@@ -22,7 +22,7 @@ module.exports.checkLambdaAlias = function (lambdaARN, alias) {
 module.exports.setLambdaPower = function (lambdaARN, value) {
     // console.log('Setting power to ', value);
     const params = {
-        FunctionName: lambdaARN, 
+        FunctionName: lambdaARN,
         MemorySize: parseInt(value),
     };
     const lambda = new AWS.Lambda();
@@ -47,7 +47,7 @@ module.exports.publishLambdaVersion = function (lambdaARN /*, alias*/) {
 module.exports.deleteLambdaVersion = function (lambdaARN, version) {
     // console.log('Deleting version ', version);
     const params = {
-        FunctionName: lambdaARN, 
+        FunctionName: lambdaARN,
         Qualifier: version,
     };
     const lambda = new AWS.Lambda();
@@ -74,7 +74,7 @@ module.exports.createLambdaAlias = function (lambdaARN, alias, version) {
 module.exports.deleteLambdaAlias = function (lambdaARN, alias) {
     // console.log('Deleting alias ', alias);
     const params = {
-        FunctionName: lambdaARN, 
+        FunctionName: lambdaARN,
         Name: alias,
     };
     const lambda = new AWS.Lambda();
@@ -87,7 +87,7 @@ module.exports.deleteLambdaAlias = function (lambdaARN, alias) {
 module.exports.invokeLambda = function (lambdaARN, alias, payload) {
     // console.log('Invoking alias ', alias);
     const params = {
-        FunctionName: lambdaARN, 
+        FunctionName: lambdaARN,
         Qualifier: alias,
         Payload: payload,
         LogType: 'Tail',  // will return logs
@@ -107,7 +107,7 @@ module.exports.computeAveragePrice = function (minCost, minRAM, value, averageDu
     // quantize price to upper 100ms (billed duration) and compute avg price
     const averagePrice = Math.ceil(averageDuration / 100) * pricePer100ms;
     // console.log('avg price: ', averagePrice);
-    return Promise.resolve(averagePrice);
+    return Promise.resolve({ "averagePrice": averagePrice, "averageDuration": averageDuration });
 };
 
 /**
@@ -123,7 +123,7 @@ module.exports.computeAverageDuration = function (results) {
     const toBeDiscarded = parseInt(results.length * 20 / 100);
 
     // build a list of floats by parsing logs
-    const durations = results.map(function(result) {
+    const durations = results.map(function (result) {
         const log = utils.base64decode(result.LogResult || '');
         return utils.extractDuration(log);
     });
@@ -141,7 +141,7 @@ module.exports.computeAverageDuration = function (results) {
         .slice(toBeDiscarded, -toBeDiscarded)  // discard first/last values
         .reduce(_add, 0)  // sum all together
         / (results.length - 2 * toBeDiscarded)  // divide by N
-    ;
+        ;
 
     return Promise.resolve(averageDuration);
 };

--- a/statemachine/template-branch.json
+++ b/statemachine/template-branch.json
@@ -10,7 +10,7 @@
     "{NUM}MB Executor": {
       "Type": "Task",
       "Resource": "arn:aws:lambda:{REGION}:{ACCOUNT_ID}:function:{EXECUTOR_FUNCTION}",
-      "ResultPath": "$.price",
+      "ResultPath": "$.stats",
       "End": true
     }
   }

--- a/test/test-lambda.js
+++ b/test/test-lambda.js
@@ -329,9 +329,7 @@ describe('Lambda Functions', function () {
                     expect(result).to.be.an('object');
                     expect(result.power).to.be('512');
                     expect(result.cost).to.be(30);
-                    expect(result.stats.averagePrice).to.be(30);
-                    expect(result.stats.averageDuration).to.be(200);
-
+                    expect(result.duration).to.be(200);
                 });
 
         });

--- a/test/test-lambda.js
+++ b/test/test-lambda.js
@@ -328,6 +328,7 @@ describe('Lambda Functions', function () {
                 .then(function (result) {
                     expect(result).to.be.an('object');
                     expect(result.power).to.be('512');
+                    expect(result.cost).to.be(30);
                     expect(result.stats.averagePrice).to.be(30);
                     expect(result.stats.averageDuration).to.be(200);
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -13,7 +13,7 @@ AWS.mock('Lambda', 'createAlias', {});
 AWS.mock('Lambda', 'deleteAlias', {});
 AWS.mock('Lambda', 'invoke', {});
 
-describe('Lambda Utils', function() {
+describe('Lambda Utils', function () {
 
     const promises = [
         utils.checkLambdaAlias,
@@ -36,9 +36,9 @@ describe('Lambda Utils', function() {
         throw new Error('Export not found! ' + func);
     }
 
-    promises.forEach(function(func) {
-        describe(_fname(func), function() {
-            it('should return a promise', function() {
+    promises.forEach(function (func) {
+        describe(_fname(func), function () {
+            it('should return a promise', function () {
                 var res = func.bind(null, 'test', 'test', 'test');
                 expect(res()).to.be.a(Promise);
             });
@@ -46,100 +46,102 @@ describe('Lambda Utils', function() {
         });
     });
 
-    describe('extractDuration', function() {
-        const log = 
+    describe('extractDuration', function () {
+        const log =
             'START RequestId: 55bc566d-1e2c-11e7-93e6-6705ceb4c1cc Version: $LATEST\n' +
             'END RequestId: 55bc566d-1e2c-11e7-93e6-6705ceb4c1cc\n' +
             'REPORT RequestId: 55bc566d-1e2c-11e7-93e6-6705ceb4c1cc\tDuration: 469.40 ms\tBilled Duration: 500 ms\tMemory Size: 1024 MB\tMax Memory Used: 21 MB'
-        ;
-        it('should extract the duration from a Lambda log', function() {
+            ;
+        it('should extract the duration from a Lambda log', function () {
             expect(utils.extractDuration(log)).to.be(469.40);
         });
-        it('should return 0 if duration is not found', function() {
+        it('should return 0 if duration is not found', function () {
             expect(utils.extractDuration('hello world')).to.be(0);
             const partialLog = 'START RequestId: 55bc566d-1e2c-11e7-93e6-6705ceb4c1cc Version: $LATEST\n';
             expect(utils.extractDuration(partialLog)).to.be(0);
         });
     });
 
-    describe('computeAveragePrice', function() {
+    describe('computeStats', function () {
         const minCost = 0.000000208;  // $
         const minRAM = 128;  // MB
         const value = 1024;  // MB
         const averageDuration = 300;  //ms
 
-        it('should return a promise', function() {
-            const price = utils.computeAveragePrice(minCost, minRAM, value, averageDuration);
+        it('should return a promise', function () {
+            const price = utils.computeStats(minCost, minRAM, value, averageDuration);
             expect(price).to.be.a(Promise);
         });
-        it('should return the average price', function() {
-            const priceFunc = utils.computeAveragePrice.bind(null, minCost, minRAM, value, averageDuration);
+        it('should return the average price', function () {
+            const statsFunc = utils.computeStats.bind(null, minCost, minRAM, value, averageDuration);
             return Promise.resolve()
-                .then(priceFunc)
-                .then(function(price) {
-                    expect(price).to.be(minCost * 8 * 3);
+                .then(statsFunc)
+                .then(function (stats) {
+                    expect(stats.averagePrice).to.be(minCost * 8 * 3);
+                    expect(stats.averageDuration).to.be(300);
+
                 });
         });
     });
 
-    describe('computeAverageDuration', function() {
+    describe('computeAverageDuration', function () {
         const results = [
             // 1s (will be discarted)
-            {'StatusCode': 200, 'LogResult': 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMS4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', 'Payload':'null'},
+            { 'StatusCode': 200, 'LogResult': 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMS4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', 'Payload': 'null' },
             // 1s
-            {'StatusCode': 200, 'LogResult': 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMS4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', 'Payload':'null'},
+            { 'StatusCode': 200, 'LogResult': 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMS4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', 'Payload': 'null' },
             // 2s -> avg!
-            {'StatusCode': 200, 'LogResult': 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMi4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', 'Payload':'null'},
+            { 'StatusCode': 200, 'LogResult': 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMi4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', 'Payload': 'null' },
             // 3s
-            {'StatusCode': 200, 'LogResult': 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMy4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', 'Payload':'null'},
+            { 'StatusCode': 200, 'LogResult': 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMy4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', 'Payload': 'null' },
             // 3s (will be discarted)
-            {'StatusCode': 200, 'LogResult': 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMy4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', 'Payload':'null'},
+            { 'StatusCode': 200, 'LogResult': 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMy4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', 'Payload': 'null' },
         ];
 
-        it('should return a promise', function() {
+        it('should return a promise', function () {
             const duration = utils.computeAverageDuration(results);
             expect(duration).to.be.a(Promise);
         });
-        it('should return the average price', function() {
+        it('should return the average price', function () {
             const durationFunc = utils.computeAverageDuration.bind(null, results);
             return Promise.resolve()
                 .then(durationFunc)
-                .then(function(duration) {
+                .then(function (duration) {
                     expect(duration).to.be(2);
                 });
         });
-        it('should return 0 if empty results', function() {
+        it('should return 0 if empty results', function () {
             const durationFunc = utils.computeAverageDuration.bind(null, []);
             return Promise.resolve()
                 .then(durationFunc)
-                .then(function(duration) {
+                .then(function (duration) {
                     expect(duration).to.be(0);
                 });
         });
     });
 
-    describe('base64decode', function() {
-        it('should convert a string to base64', function() {
+    describe('base64decode', function () {
+        it('should convert a string to base64', function () {
             expect(utils.base64decode('aGVsbG8gd29ybGQ=')).to.be('hello world');
             expect(utils.base64decode('bG9yZW0gaXBzdW0=')).to.be('lorem ipsum');
         });
-        it('should explode with non-string arguments', function() {
+        it('should explode with non-string arguments', function () {
             expect(utils.base64decode.bind(null, null)).to.throwError();
             expect(utils.base64decode.bind(null, undefined)).to.throwError();
             expect(utils.base64decode.bind(null, 10)).to.throwError();
         });
     });
 
-    describe('range', function() {
-        it('should generate a list of size N', function() {
+    describe('range', function () {
+        it('should generate a list of size N', function () {
             expect(utils.range(0)).to.have.length(0);
             expect(utils.range(5)).to.have.length(5);
             expect(utils.range(50)).to.have.length(50);
             expect(utils.range(500)).to.have.length(500);
         });
-        it('should explode when called with invalid arguments', function() {
-            [-1, -2, -Infinity, Infinity, null, undefined].forEach(function(val) {
-                expect(utils.range.bind(null, val)).to.throwError();    
+        it('should explode when called with invalid arguments', function () {
+            [-1, -2, -Infinity, Infinity, null, undefined].forEach(function (val) {
+                expect(utils.range.bind(null, val)).to.throwError();
             });
         });
     });


### PR DESCRIPTION
I have been using and enjoy the tool and cost is a big consideration when picking a POWER for lambda, but SLA's are also important, so I wanted to display both cost and duration in the results. The finalizer still orders and suggests the result from price only.
