### PR TITLE
Add minimum number of invokes, fix base.yml for some serverless versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Once the execution has completed, you will find the execution results in the "**
 The AWS Step Functions state machine accepts the following parameters:
 
 * **lambdaARN** (required, string): ARN of the Lambda Function you want to optimize
-* **num** (required, integer): the # of invocations for each power configuration (recommended: between 10 and 100)
+* **num** (required, integer): the # of invocations for each power configuration (minimum 5, recommended: between 10 and 100)
 * **payload** (string or object): the static payload that will be used for every invocation
 * **parallelInvocation** (false by default): if true, all the invocations will be executed in parallel (note: depending on the value of `num`, you may experience throttling when setting `parallelInvocation` to true)
 

--- a/lambda/initializer.js
+++ b/lambda/initializer.js
@@ -13,6 +13,7 @@ const powerValues = process.env.powerValues.split(',');
 module.exports.handler = (event, context, callback) => {
 
     const lambdaARN = event.lambdaARN;
+    const num = event.num;
 
     if (!lambdaARN) {
         throw new Error('Missing or empty lambdaARN');
@@ -20,6 +21,10 @@ module.exports.handler = (event, context, callback) => {
 
     if (!powerValues.length) {
         throw new Error('Missing or empty env.powerValues');
+    }
+
+    if (!num || num < 5) {
+        throw new Error('Missing num or num below 5')
     }
 
     var queue = Promise.resolve();

--- a/serverless.base.yml
+++ b/serverless.base.yml
@@ -10,8 +10,8 @@ provider:
       Resource: '*'
   environment:
     powerValues: '128,256,512,1024,1536'
-    minRAM: 128
-    minCost: 2.08e-7
+    minRAM: '128'
+    minCost: '0.000000208'
 package:
   include:
     - lambda/**


### PR DESCRIPTION
Found that when running with 4 or less invocation, no results are displayed partly because of the 20% outlier filtering. It took me a while to realize this so it might be good to make this a bit more clear. Also I found that my serverless version did not accept the base.yml file, found the fix in the issues forum but no pull request yet. 

Let me know if there are any issues with this pull request.