### PR TITLE
Add optional support for Nodejs 10.x as runtime

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -21,10 +21,14 @@ Parameters:
     # Default: 128,192,256,320,384,448,512,576,640,704,768,832,896,960,1024,1088,1152,1216,1280,1344,1408,1472,1536,3008
     # AllowedValues: ['128','192','256','320','384','448','512','576','640','704','768','832','896','960','1024','1088','1152','1216','1280','1344','1408','1472','1536','3008']
     Description: Comma-separated RAM values.
+  NodeVersion:
+    Type: String
+    Default: nodejs8.10
+    Description: Runtime node version
 
 Globals:
   Function:
-    Runtime: nodejs8.10
+    Runtime: !Ref NodeVersion
     Timeout: 60
     MemorySize: 128
     Environment:


### PR DESCRIPTION
This is a fix for issue #24 . Similar to how `PowerValues` are added, we can set the Global Functions Runtime to be whatever we want by passing `NodeVersion` as a deploy config variable