### PR TITLE
Retry policies & failed invocations

### DIFF
--- a/lambda/executor.js
+++ b/lambda/executor.js
@@ -68,6 +68,10 @@ const runInParallel = async(num, lambdaARN, lambdaAlias, payload) => {
     // run all invocations in parallel ...
     const invocations = utils.range(num).map(async() => {
         const data = await utils.invokeLambda(lambdaARN, lambdaAlias, payload);
+        // invocation errors return 200 and contain FunctionError and Payload
+        if (data.FunctionError) {
+            throw new Error('Invocation error: ' + data.Payload);
+        }
         results.push(data);
     });
     // ... and wait for results
@@ -80,6 +84,10 @@ const runInSeries = async(num, lambdaARN, lambdaAlias, payload) => {
     for (let i = 0; i < num; i++) {
         // run invocations in series
         const data = await utils.invokeLambda(lambdaARN, lambdaAlias, payload);
+        // invocation errors return 200 and contain FunctionError and Payload
+        if (data.FunctionError) {
+            throw new Error('Invocation error: ' + data.Payload);
+        }
         results.push(data);
     }
     return results;

--- a/template.yml
+++ b/template.yml
@@ -131,7 +131,7 @@ Resources:
                       "Type": "Parallel",
                       "Next": "After Branching",
                       "Catch": [{
-                        "ErrorEquals": [ "States.ALL" ],
+                        "ErrorEquals": ["States.ALL"],
                         "Next": "CleanUpOnError",
                         "ResultPath": "$.error"
                       }],
@@ -149,7 +149,12 @@ Resources:
                                       "Type": "Task",
                                       "Resource": "${executorArn}",
                                       "ResultPath": "$.stats",
-                                      "End": true
+                                      "End": true,
+                                      "Retry": [{
+                                          "ErrorEquals": ["States.ALL"],
+                                          "IntervalSeconds": 3,
+                                          "MaxAttempts": 2
+                                      }]
                                   }
                               }
                           },
@@ -166,7 +171,12 @@ Resources:
                                       "Type": "Task",
                                       "Resource": "${executorArn}",
                                       "ResultPath": "$.stats",
-                                      "End": true
+                                      "End": true,
+                                      "Retry": [{
+                                          "ErrorEquals": ["States.ALL"],
+                                          "IntervalSeconds": 3,
+                                          "MaxAttempts": 2
+                                      }]
                                   }
                               }
                           },
@@ -183,7 +193,12 @@ Resources:
                                       "Type": "Task",
                                       "Resource": "${executorArn}",
                                       "ResultPath": "$.stats",
-                                      "End": true
+                                      "End": true,
+                                      "Retry": [{
+                                          "ErrorEquals": ["States.ALL"],
+                                          "IntervalSeconds": 3,
+                                          "MaxAttempts": 2
+                                      }]
                                   }
                               }
                           },
@@ -200,7 +215,12 @@ Resources:
                                       "Type": "Task",
                                       "Resource": "${executorArn}",
                                       "ResultPath": "$.stats",
-                                      "End": true
+                                      "End": true,
+                                      "Retry": [{
+                                          "ErrorEquals": ["States.ALL"],
+                                          "IntervalSeconds": 3,
+                                          "MaxAttempts": 2
+                                      }]
                                   }
                               }
                           },
@@ -217,7 +237,12 @@ Resources:
                                       "Type": "Task",
                                       "Resource": "${executorArn}",
                                       "ResultPath": "$.stats",
-                                      "End": true
+                                      "End": true,
+                                      "Retry": [{
+                                          "ErrorEquals": ["States.ALL"],
+                                          "IntervalSeconds": 3,
+                                          "MaxAttempts": 2
+                                      }]
                                   }
                               }
                           },
@@ -234,7 +259,12 @@ Resources:
                                       "Type": "Task",
                                       "Resource": "${executorArn}",
                                       "ResultPath": "$.stats",
-                                      "End": true
+                                      "End": true,
+                                      "Retry": [{
+                                          "ErrorEquals": ["States.ALL"],
+                                          "IntervalSeconds": 3,
+                                          "MaxAttempts": 2
+                                      }]
                                   }
                               }
                           }

--- a/test/test-lambda.js
+++ b/test/test-lambda.js
@@ -37,14 +37,18 @@ const invokeForSuccess = async(handler, event) => {
 // utility to invoke handler (success case)
 const invokeForFailure = async(handler, event) => {
 
+    let result;
+
     try {
-        const result = await handler(event, fakeContext);
-        expect(result).to.be(null);
-        throw new Error('should have thrown an error, instead got: ', result);
+        result = await handler(event, fakeContext);
     } catch (error) {
         expect(error).to.not.be(null);
         return error;
     }
+
+    expect(result).to.be(null);
+    // throw new Error('should have thrown an error, instead got: ', result);
+
 };
 
 
@@ -302,6 +306,22 @@ describe('Lambda Functions', async() => {
                 });
                 expect(invokeLambdaCounter).to.be(num);
             });
+        });
+
+        it('should report an error if invocation fails', async() => {
+            utils.invokeLambda = async() => {
+                console.log('YOOOO');
+                return {
+                    FunctionError: 'Unhandled',
+                    Payload: '{"errorType": "MemoryError", "stackTrace": [["/var/task/lambda_function.py", 11, "lambda_handler", "blabla"], ["/var/task/lambda_function.py", 7, "blabla]]}',
+                };
+            };
+            await invokeForFailure(handler, {
+                lambdaARN: 'arnOK',
+                value: '1024',
+                num: 10,
+            });
+
         });
 
         it('should return price as output', async() => {

--- a/test/test-lambda.js
+++ b/test/test-lambda.js
@@ -310,7 +310,6 @@ describe('Lambda Functions', async() => {
 
         it('should report an error if invocation fails', async() => {
             utils.invokeLambda = async() => {
-                console.log('YOOOO');
                 return {
                     FunctionError: 'Unhandled',
                     Payload: '{"errorType": "MemoryError", "stackTrace": [["/var/task/lambda_function.py", 11, "lambda_handler", "blabla"], ["/var/task/lambda_function.py", 7, "blabla]]}',


### PR DESCRIPTION
I have added specific check to intercept failed executions.

Note: invocation errors just return 200 and come with a `FunctionError` and `Payload` with error information.