### PR TITLE
Added overall execution cost information (state machine output)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
         "mocha": true
     },
     "rules": {
-        "indent": ["error", 4]
+        "indent": ["error", 4],
+        "max-len": "off"
     },
     "extends": "strongloop"
 }

--- a/README-SAR.md
+++ b/README-SAR.md
@@ -53,6 +53,8 @@ The AWS Step Functions state machine will return the following outputs:
 
 If something goes wrong during the initialization or execution states, the `CleanUpOnError` step will be executed. All versions and alises will be deleted as expected (the same happens in the `Cleaner` step).
 
+Note: the error `Lambda.Unknown` corresponds to unhandled errors in Lambda such as out-of-memory errors, function timeouts, and hitting the concurrent Lambda invoke limit. If you encounter it as input of `CleanUpOnError`, it's very likely that the Executor function has timed out and you'll need to enable `parallelInvocation`.
+
 ### Retry policy
 
 The executor will retry twice in case any invocation fails. This is helpful in case of execution timeouts or memory errors. You will find the failed execution's stack trace in the `CleanUpOnError` state input.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The AWS Step Functions state machine will return the following outputs:
 
 If something goes wrong during the initialization or execution states, the `CleanUpOnError` step will be executed. All versions and alises will be deleted as expected (the same happens in the `Cleaner` step).
 
+Note: the error `Lambda.Unknown` corresponds to unhandled errors in Lambda such as out-of-memory errors, function timeouts, and hitting the concurrent Lambda invoke limit. If you encounter it as input of `CleanUpOnError`, it's very likely that the Executor function has timed out and you'll need to enable `parallelInvocation`.
+
 ### Retry policy
 
 The executor will retry twice in case any invocation fails. This is helpful in case of execution timeouts or memory errors. You will find the failed execution's stack trace in the `CleanUpOnError` state input.

--- a/lambda/executor.js
+++ b/lambda/executor.js
@@ -95,10 +95,24 @@ const runInSeries = async(num, lambdaARN, lambdaAlias, payload) => {
 
 const computeStatistics = (results, value) => {
     // use results (which include logs) to compute average duration ...
-    const averageDuration = utils.computeAverageDuration(results);
+
+    const durations = utils.parseLogAndExtractDurations(results);
+
+    const averageDuration = utils.computeAverageDuration(durations);
     console.log('Average duration: ', averageDuration);
+
     // ... and overall statistics
-    const stats = utils.computeStats(minCost, minRAM, value, averageDuration);
+    const averagePrice = utils.computePrice(minCost, minRAM, value, averageDuration);
+
+    // .. and total cost (exact $)
+    const totalCost = utils.computeTotalCost(minCost, minRAM, value, durations);
+
+    const stats = {
+        averagePrice,
+        averageDuration,
+        totalCost,
+    };
+
     console.log('Stats: ', stats);
     return stats;
 };

--- a/lambda/finalizer.js
+++ b/lambda/finalizer.js
@@ -1,15 +1,12 @@
 'use strict';
 
+const utils = require('./utils');
+
 const defaultStrategy = 'cost';
 const optimizationStrategies = {
     cost: () => findCheapest,
     speed: () => findFastest,
 };
-
-// cost of 18 state transitions (AWS Step Functions)
-const fixedCostStepFunctions = +(0.000025 * 18).toFixed(5);
-
-module.exports.fixedCost = fixedCostStepFunctions;
 
 /**
  * Receive average cost and decide which power config wins.
@@ -36,7 +33,7 @@ const findOptimalConfiguration = (event) => {
 
     // also compute total cost of optimization state machine & lambda
     optimal.stateMachine = {};
-    optimal.stateMachine.executionCost = fixedCostStepFunctions;
+    optimal.stateMachine.executionCost = utils.fixedCostStepFunctions;
     optimal.stateMachine.lambdaCost = stats
         .map((p) => p.totalCost)
         .reduce((a, b) => a + b, 0);

--- a/lambda/finalizer.js
+++ b/lambda/finalizer.js
@@ -38,7 +38,7 @@ const findOptimalConfiguration = (event) => {
     optimal.stateMachine = {};
     optimal.stateMachine.executionCost = fixedCostStepFunctions;
     optimal.stateMachine.lambdaCost = stats
-        .map((p) => p.totalCost || 0)
+        .map((p) => p.totalCost)
         .reduce((a, b) => a + b, 0);
 
     // the total cost of the optimal branch execution is not needed

--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -5,6 +5,9 @@ const AWS = require('aws-sdk');
 // local reference to this module
 const utils = module.exports;
 
+// cost of 18 state transitions (AWS Step Functions)
+module.exports.fixedCostStepFunctions = +(0.000025 * 18).toFixed(5);
+
 /**
  * Check whether a Lambda Alias exists or not, and return its data.
  */

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "deploy": "bash deploy.sh",
     "execute": "bash execute.sh",
-    "lint": "jslint --ignore-path .gitignore .",
+    "lint": "eslint --ignore-path .gitignore .",
     "test": "mocha",
     "coverage": "nyc --reporter=lcov npm run test"
   },

--- a/template.yml
+++ b/template.yml
@@ -25,7 +25,6 @@ Parameters:
 Globals:
   Function:
     Runtime: nodejs8.10
-    Timeout: 60
     MemorySize: 128
     Environment:
       Variables:
@@ -59,6 +58,7 @@ Resources:
     Properties:
       CodeUri: lambda
       Handler: executor.handler
+      Timeout: 300
       Policies:
         - AWSLambdaExecute # Managed Policy
         - Version: '2012-10-17' # Policy Document
@@ -73,6 +73,7 @@ Resources:
     Properties:
       CodeUri: lambda
       Handler: cleaner.handler
+      Timeout: 60
       Policies:
         - AWSLambdaExecute # Managed Policy
         - Version: '2012-10-17' # Policy Document
@@ -89,6 +90,7 @@ Resources:
     Properties:
       CodeUri: lambda
       Handler: finalizer.handler
+      Timeout: 10
       Policies:
         - AWSLambdaExecute # Managed Policy
 
@@ -120,7 +122,7 @@ Resources:
                       "Type": "Task",
                       "Resource": "${initializerArn}",
                       "Next": "Branching",
-                      "ResultPath": "$.OK",
+                      "ResultPath": null,
                       "Catch": [{
                         "ErrorEquals": [ "States.ALL" ],
                         "Next": "CleanUpOnError",
@@ -272,7 +274,7 @@ Resources:
                   },
                   "After Branching": {
                       "Type": "Parallel",
-                      "End": true,
+                      "Next": "Success",
                       "Branches": [
                           {
                               "StartAt": "Finalizer",
@@ -298,6 +300,13 @@ Resources:
                               }
                           }
                       ]
+                  },
+                  "Success": {
+                      "Type": "Pass",
+                      "Parameters": {
+                          "results.$": "$[0]"
+                      },
+                      "End": true
                   },
                   "CleanUpOnError": {
                       "Type": "Task",

--- a/test/test-lambda.js
+++ b/test/test-lambda.js
@@ -421,7 +421,7 @@ describe('Lambda Functions', async() => {
     describe('finalizer', () => {
 
         const handler = require('../lambda/finalizer').handler;
-        const fixedCost = require('../lambda/finalizer').fixedCost;
+        const fixedCost = utils.fixedCostStepFunctions;
 
         it('should explode if invoked without invalid event', async() => {
             const invalidEvents = [

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -122,6 +122,24 @@ describe('Lambda Utils', () => {
         });
     });
 
+    describe('computeTotalCost', () => {
+        const minCost = 0.000000208; // $
+        const minRAM = 128; // MB
+        const value = 1024; // MB
+        const durations = [
+            100, 200, 200, 300, 400,
+        ];
+
+        it('should return the total cost', () => {
+            const duration = utils.computeTotalCost(minCost, minRAM, value, durations);
+            expect(duration).to.be(minCost * 8 * (1 + 2 + 2 + 3 + 4));
+        });
+        it('should return 0 if empty durations', () => {
+            const duration = utils.computeTotalCost(minCost, minRAM, value, []);
+            expect(duration).to.be(0);
+        });
+    });
+
     describe('base64decode', () => {
         it('should convert a string to base64', () => {
             expect(utils.base64decode('aGVsbG8gd29ybGQ=')).to.be('hello world');

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -67,21 +67,20 @@ describe('Lambda Utils', () => {
         });
     });
 
-    describe('computeStats', () => {
+    describe('computePrice', () => {
         const minCost = 0.000000208; // $
         const minRAM = 128; // MB
         const value = 1024; // MB
         const averageDuration = 300; // ms
 
         it('should return the average price', () => {
-            const stats = utils.computeStats(minCost, minRAM, value, averageDuration);
-            expect(stats).to.be.an('object');
-            expect(stats.averagePrice).to.be(minCost * 8 * 3);
-            expect(stats.averageDuration).to.be(300);
+            const avgPrice = utils.computePrice(minCost, minRAM, value, averageDuration);
+            expect(avgPrice).to.be.a('number');
+            expect(avgPrice).to.be(minCost * 8 * 3);
         });
     });
 
-    describe('computeAverageDuration', () => {
+    describe('parseLogAndExtractDurations', () => {
         const results = [
             // 1s (will be discarted)
             { StatusCode: 200, LogResult: 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMS4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', Payload: 'null' },
@@ -95,8 +94,26 @@ describe('Lambda Utils', () => {
             { StatusCode: 200, LogResult: 'U1RBUlQgUmVxdWVzdElkOiA0NzlmYjUxYy0xZTM4LTExZTctOTljYS02N2JmMTYzNjA4ZWQgVmVyc2lvbjogOTkKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTEgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTIgPSB1bmRlZmluZWQKMjAxNy0wNC0xMFQyMTo1NDozMi42ODNaCTQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAl2YWx1ZTMgPSB1bmRlZmluZWQKRU5EIFJlcXVlc3RJZDogNDc5ZmI1MWMtMWUzOC0xMWU3LTk5Y2EtNjdiZjE2MzYwOGVkClJFUE9SVCBSZXF1ZXN0SWQ6IDQ3OWZiNTFjLTFlMzgtMTFlNy05OWNhLTY3YmYxNjM2MDhlZAlEdXJhdGlvbjogMy4wIG1zCUJpbGxlZCBEdXJhdGlvbjogMTAwIG1zIAlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTUgTUIJCg==', Payload: 'null' },
         ];
 
-        it('should return the average price', () => {
-            const duration = utils.computeAverageDuration(results);
+        it('should return the list of durations', () => {
+            const durations = utils.parseLogAndExtractDurations(results);
+            expect(durations).to.be.a('array');
+            expect(durations.length).to.be(5);
+            expect(durations).to.eql([1, 1, 2, 3, 3]);
+        });
+        it('should return empty list if empty results', () => {
+            const durations = utils.parseLogAndExtractDurations([]);
+            expect(durations).to.be.an('array');
+            expect(durations.length).to.be(0);
+        });
+    });
+
+    describe('computeAverageDuration', () => {
+        const durations = [
+            1, 1, 2, 3, 3,
+        ];
+
+        it('should return the average duration', () => {
+            const duration = utils.computeAverageDuration(durations);
             expect(duration).to.be(2);
         });
         it('should return 0 if empty results', () => {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -105,6 +105,14 @@ describe('Lambda Utils', () => {
             expect(durations).to.be.an('array');
             expect(durations.length).to.be(0);
         });
+
+        it('should not explode if missing logs', () => {
+            const durations = utils.parseLogAndExtractDurations([
+                { StatusCode: 200, Payload: 'null' },
+            ]);
+            expect(durations).to.be.an('array');
+            expect(durations).to.eql([0]);
+        });
     });
 
     describe('computeAverageDuration', () => {


### PR DESCRIPTION
Implements #33 

The new state machine output looks as follows:

```json
{
  "results": {
    "power": "128",
    "cost": 2.08e-7,
    "duration": 2.9066666666666667,
    "stateMachine": {
      "executionCost": 0.00045,
      "lambdaCost": 0.0005252
    }
  }
}
```


Note: this is a breaking change in the state machine output (the previous output was a list of two objects, resulting from the parallel state [Finalizer + Cleaner]).

What I've implemented?

- new `Success` status to re-map the `Finalizer` output properly
- new `stateMachine` output, containing `executionCost` (Step Functions cost) and `lambdaCost` (Lambda cost)