### PR TITLE
Add visualization URL to state machine output

### DIFF
--- a/lambda/finalizer.js
+++ b/lambda/finalizer.js
@@ -2,6 +2,8 @@
 
 const utils = require('./utils');
 
+const visualizationURL = process.env.visualizationURL;
+
 const defaultStrategy = 'cost';
 const optimizationStrategies = {
     cost: () => findCheapest,
@@ -37,6 +39,7 @@ const findOptimalConfiguration = (event) => {
     optimal.stateMachine.lambdaCost = stats
         .map((p) => p.totalCost)
         .reduce((a, b) => a + b, 0);
+    optimal.stateMachine.visualization = utils.buildVisualizationURL(stats, visualizationURL);
 
     // the total cost of the optimal branch execution is not needed
     delete optimal.totalCost;

--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -207,3 +207,31 @@ module.exports.lambdaClientFromARN = (lambdaARN) => {
     const region = lambdaARN.split(':')[3];
     return new AWS.Lambda({region});
 };
+
+/**
+ * Generate a URL with encoded stats.
+ * Note: the URL hash is never sent to the server.
+ */
+module.exports.buildVisualizationURL = (stats, baseURL) => {
+
+    function encode(inputList, EncodeType = Float32Array) {
+        inputList = new EncodeType(inputList);
+        if (!(inputList instanceof Uint8Array)) {
+            inputList = new Uint8Array(inputList.buffer);
+        }
+        return Buffer.from(inputList).toString('base64');
+    }
+
+    // sort by power
+    stats.sort((p1, p2) => {
+        return p1.power - p2.power;
+    });
+
+    const sizes = stats.map(p => p.power);
+    const times = stats.map(p => p.duration);
+    const costs = stats.map(p => p.cost);
+
+    const hash = encode(sizes, Int16Array) + ';' + encode(times) + ';' + encode(costs);
+
+    return baseURL + '#' + hash;
+};

--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -214,7 +214,8 @@ module.exports.lambdaClientFromARN = (lambdaARN) => {
  */
 module.exports.buildVisualizationURL = (stats, baseURL) => {
 
-    function encode(inputList, EncodeType = Float32Array) {
+    function encode(inputList, EncodeType = null) {
+        EncodeType = EncodeType || Float32Array;
         inputList = new EncodeType(inputList);
         if (!(inputList instanceof Uint8Array)) {
             inputList = new Uint8Array(inputList.buffer);

--- a/template.yml
+++ b/template.yml
@@ -31,6 +31,7 @@ Globals:
         powerValues: !Join [ ",", !Ref PowerValues ]
         minRAM: '128'
         minCost: '0.000000208'
+        visualizationURL: 'https://master.d19f2a8daatc3f.amplifyapp.com'
 
 Resources:
 

--- a/test/test-lambda.js
+++ b/test/test-lambda.js
@@ -455,6 +455,19 @@ describe('Lambda Functions', async() => {
             expect(result.stateMachine.lambdaCost).to.be(6);
         });
 
+        it('should also return visualization URL', async() => {
+            const event = [
+                { value: '128', stats: { averagePrice: 100, averageDuration: 100, totalCost: 1 } },
+                { value: '256', stats: { averagePrice: 200, averageDuration: 300, totalCost: 2 } },
+                { value: '512', stats: { averagePrice: 30, averageDuration: 200, totalCost: 3 } },
+            ];
+
+            const result = await invokeForSuccess(handler, event);
+            expect(result).to.be.an('object');
+            expect(result.stateMachine).to.be.an('object');
+            expect(result.stateMachine.visualization).to.be.a('string');
+        });
+
         it('should return the cheapest power configuration if no strategy', async() => {
             const event = [
                 { value: '128', stats: { averagePrice: 100, averageDuration: 100, totalCost: 1 } },

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -188,4 +188,23 @@ describe('Lambda Utils', () => {
         });
     });
 
+    describe('buildVisualizationURL', () => {
+        it('should return the visualization URL based on stats', () => {
+            const stats = [
+                {power: 1, duration: 2, cost: 3},
+                {power: 2, duration: 2, cost: 2},
+                {power: 3, duration: 1, cost: 2},
+            ];
+            const prefix = 'https://prefix/';
+            const URL = utils.buildVisualizationURL(stats, prefix);
+            expect(URL).to.be.a('string');
+            expect(URL).to.contain('prefix');
+            expect(URL).to.contain('#');
+            expect(URL).to.contain(';');
+            expect(URL).to.contain('AQACAAMA'); // powers
+            expect(URL).to.contain('AAAAQAAAAEAAAIA'); // times
+            expect(URL).to.contain('AABAQAAAAEAAAABA'); // costs
+        });
+    });
+
 });


### PR DESCRIPTION
Implements #40 

New state machine output:

```json
{
  "results": {
    "power": "1024",
    "cost": 0.000064896,
    "duration": 3890.8916666666664,
    "stateMachine": {
      "executionCost": 0.00045,
      "lambdaCost": 0.00455936,
      "visualization": "https://lambda-power-tuning.show/#gAAAAQACAAQABsAL;ZooQR4yvkUa/pQRGRC5zRaADHUVjOftE;QdWhOEMkoziDT5Q4xhiIOMYYiDi6RNc4"
    }
  }
}
```

The visualization URL will allow users to visualize and inspect statistics in an external web app. 

Notes:
- no data is actually sent to the visualization web app (URL hash stays in the browser)
- documentation to be added
- the webapp repo is [here](https://github.com/alexcasalboni/aws-lambda-power-tuning-ui) (it's a fork)
