### PR TITLE
Implement new lambdaResource CFN parameter

### DIFF
--- a/README-SAR.md
+++ b/README-SAR.md
@@ -23,7 +23,7 @@ The state machine name will be prefixed with `powerTuningStateMachine`. Find it 
     "powerValues": [128, 256, 512, 1024, 2048, 3008],
     "num": 10,
     "payload": "{}",
-    "parallelInvocation": false,
+    "parallelInvocation": true,
     "strategy": "cost"
 }
 ```
@@ -106,6 +106,21 @@ If you don't want to use the visualization tool, you can simply ignore the `stat
 Website repository: [matteo-ronchetti/aws-lambda-power-tuning-ui](https://github.com/matteo-ronchetti/aws-lambda-power-tuning-ui)
 
 Optionally, you could deploy your own custom visualization tool and configure the CloudFormation Parameter named `visualizationURL` with your own URL.
+
+## Security
+
+All the IAM roles used by the state machine adopt the least privilege best practice, meaning that only a minimal set of `Actions` are granted to each Lambda function.
+
+For example, the Executor function can only call `lambda:InvokeFunction`. The Analyzer function doesn't require any permission at all. On the other hand, the Initializer, Cleaner, and Optimizer functions require a broader set of actions.
+
+Although the default resource is `"*"`, you can optionally configure the `lambdaResource` CloudFormation parameter at deploy-time to constrain the IAM permission even more.
+
+For example, you could use a mix of the following:
+
+* Same-region prefix: `arn:aws:lambda:us-east-1:*:function:*`
+* Function name prefix: `arn:aws:lambda:*:*:function:my-prefix-*`
+* Function name suffix: `arn:aws:lambda:*:*:function:*-dev`
+* By account ID: `arn:aws:lambda:*:ACCOUNT_ID:function:*`
 
 ## State machine cost
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Here you can provide the execution input and an execution id (see section below 
     "powerValues": [128, 256, 512, 1024, 2048, 3008],
     "num": 10,
     "payload": {},
-    "parallelInvocation": false,
+    "parallelInvocation": true,
     "strategy": "cost"
 }
 ```
@@ -167,6 +167,21 @@ If you don't want to use the visualization tool, you can simply ignore the `stat
 Website repository: [matteo-ronchetti/aws-lambda-power-tuning-ui](https://github.com/matteo-ronchetti/aws-lambda-power-tuning-ui)
 
 Optionally, you could deploy your own custom visualization tool and configure the CloudFormation Parameter named `visualizationURL` with your own URL.
+
+## Security
+
+All the IAM roles used by the state machine adopt the least privilege best practice, meaning that only a minimal set of `Actions` are granted to each Lambda function.
+
+For example, the Executor function can only call `lambda:InvokeFunction`. The Analyzer function doesn't require any permission at all. On the other hand, the Initializer, Cleaner, and Optimizer functions require a broader set of actions.
+
+Although the default resource is `"*"`, you can optionally configure the `lambdaResource` CloudFormation parameter at deploy-time to constrain the IAM permission even more.
+
+For example, you could use a mix of the following:
+
+* Same-region prefix: `arn:aws:lambda:us-east-1:*:function:*`
+* Function name prefix: `arn:aws:lambda:*:*:function:my-prefix-*`
+* Function name suffix: `arn:aws:lambda:*:*:function:*-dev`
+* By account ID: `arn:aws:lambda:*:ACCOUNT_ID:function:*`
 
 ## State machine cost
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,9 +2,10 @@
 BUCKET_NAME=your-sam-templates-bucket
 STACK_NAME=lambda-power-tuning
 PowerValues='128,256,512,1024,1536,3008'
+LambdaResource='*'
 
 # package
 sam package --s3-bucket $BUCKET_NAME --template-file template.yml --output-template-file packaged.yml
 
 # deploy
-sam deploy --template-file packaged.yml --stack-name $STACK_NAME --capabilities CAPABILITY_IAM --parameter-overrides PowerValues=$PowerValues
+sam deploy --template-file packaged.yml --stack-name $STACK_NAME --capabilities CAPABILITY_IAM --parameter-overrides PowerValues=$PowerValues lambdaResource=$LambdaResource

--- a/sample-execution-input.json
+++ b/sample-execution-input.json
@@ -1,6 +1,8 @@
 {
     "lambdaARN": "arn:aws:lambda:XXX:YYY:function:ZZZ",
+    "powerValues": [128, 256, 512, 3008],
     "num": 5,
+    "payload": {},
     "parallelInvocation": true,
-    "payload": "{}"
+    "strategy": "cost"
 }

--- a/template.yml
+++ b/template.yml
@@ -25,6 +25,10 @@ Parameters:
     Type: String
     Default: https://lambda-power-tuning.show/
     Description: Stats visualization URL
+  lambdaResource:
+    Type: String
+    Default: '*'
+    Description: AWS Lambda resource (or prefix) to be used for IAM policies
 
 Globals:
   Function:
@@ -57,7 +61,7 @@ Resources:
                 - lambda:UpdateFunctionConfiguration
                 - lambda:CreateAlias
                 - lambda:UpdateAlias
-              Resource: '*'
+              Resource: !Ref lambdaResource
 
   executor:
     Type: AWS::Serverless::Function
@@ -71,7 +75,7 @@ Resources:
             - Effect: Allow
               Action:
                 - lambda:InvokeFunction
-              Resource: '*'
+              Resource: !Ref lambdaResource
 
   cleaner:
     Type: AWS::Serverless::Function
@@ -87,7 +91,7 @@ Resources:
                 - lambda:GetAlias
                 - lambda:DeleteAlias
                 - lambda:DeleteFunction  # only by version/qualifier
-              Resource: '*'
+              Resource: !Ref lambdaResource
 
   analyzer:
     Type: AWS::Serverless::Function
@@ -114,7 +118,7 @@ Resources:
                 - lambda:UpdateFunctionConfiguration
                 - lambda:CreateAlias
                 - lambda:UpdateAlias
-              Resource: '*'
+              Resource: !Ref lambdaResource
 
   statemachineRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Implements #52 

New CloudFormation parameter named `lambdaResource`.

The default value is still `*`, but it can be customized at deploy-time.

Goal: reduce blast radius and provide an easy way to follow least-privilege best practice.