### PR TITLE
Implement dryRun option

### DIFF
--- a/lambda/analyzer.js
+++ b/lambda/analyzer.js
@@ -21,6 +21,10 @@ module.exports.handler = async(event, context) => {
         throw new Error('Wrong input ' + JSON.stringify(event));
     }
 
+    if (event.dryRun) {
+        return console.log('[Dry-run] Skipping analysis');
+    }
+
     return findOptimalConfiguration(event);
 };
 

--- a/lambda/executor.js
+++ b/lambda/executor.js
@@ -11,9 +11,15 @@ const minCost = parseFloat(process.env.minCost);
  */
 module.exports.handler = async(event, context) => {
     // read input from event
-    const {lambdaARN, value, num, enableParallel, payload} = extractDataFromInput(event);
+    let {lambdaARN, value, num, enableParallel, payload, dryRun} = extractDataFromInput(event);
 
     validateInput(lambdaARN, value, num); // may throw
+
+    // force only 1 execution if dryRun
+    if (dryRun) {
+        console.log('[Dry-run] forcing num=1');
+        num = 1;
+    }
 
     const lambdaAlias = 'RAM' + value;
     let results;
@@ -49,6 +55,7 @@ const extractDataFromInput = (event) => {
         num: parseInt(event.num, 10),
         enableParallel: !!event.parallelInvocation,
         payload: event.payload,
+        dryRun: event.dryRun === true,
     };
 };
 

--- a/lambda/optimizer.js
+++ b/lambda/optimizer.js
@@ -7,11 +7,15 @@ const utils = require('./utils');
  */
 module.exports.handler = async(event, context) => {
 
-    const {lambdaARN, analysis, autoOptimize, autoOptimizeAlias} = event;
+    const {lambdaARN, analysis, autoOptimize, autoOptimizeAlias, dryRun} = event;
 
     const optimalValue = (analysis || {}).power;
 
     validateInput(lambdaARN, optimalValue); // may throw
+
+    if (dryRun) {
+        return console.log('[Dry-run] Not optimizing');
+    }
 
     if (!autoOptimize) {
         return console.log('Not optimizing');


### PR DESCRIPTION
Implement #41 

The new `dryRun` option allows you to verify that permissions and input function are correctly configured.
It will run the input function only once (independently of the value of `num`).
It also disable logs analysis and auto-optimization logic.