### PR TITLE
Update base cost to $0.0000002083

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,5 @@
 # config
-BUCKET_NAME=sam-templates-demos-dublin
+BUCKET_NAME=your-sam-templates-bucket
 STACK_NAME=lambda-power-tuning
 PowerValues='128,256,512,1024,1536,3008'
 LambdaResource='*'

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,5 @@
 # config
-BUCKET_NAME=your-sam-templates-bucket
+BUCKET_NAME=sam-templates-demos-dublin
 STACK_NAME=lambda-power-tuning
 PowerValues='128,256,512,1024,1536,3008'
 LambdaResource='*'

--- a/template.yml
+++ b/template.yml
@@ -39,7 +39,7 @@ Globals:
       Variables:
         defaultPowerValues: !Join [ ",", !Ref PowerValues ]
         minRAM: '128'
-        minCost: '0.000000208'
+        minCost: '0.0000002083'
         visualizationURL: !Ref visualizationURL
 
 Resources:


### PR DESCRIPTION
Fix #75 

I'm not 100% sure why the base cost was incorrectly set at `$0.000000208`. It might have been a refactoring error/typo or maybe it just was never updated since the initial version of this tool was created in 2017.

Nevertheless, this minor inaccuracy of the absolute value shouldn't have impacted the cost/performance pattern evaluation.