### PR TITLE
update readme to show deploying with cdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,34 @@ You can finally deploy the serverless app:
 $ bash scripts/deploy.sh
 ```
 
+## How to deploy the state machine (AWS CDK)
+
+First, [install AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/getting_started.html) and [configure your AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#cli-quick-configuration):
+
+```bash
+$ pip install aws-sam-cli
+$ aws configure
+```
+
+Now we can use [CDK Patterns](https://github.com/cdk-patterns/serverless) to give us a pre configured project in either TypeScript or Python:
+
+```bash
+# For the TypeScript CDK version
+npx cdkp init the-lambda-power-tuner
+
+# or for the Python CDK version
+npx cdkp init the-lambda-power-tuner --lang=python
+```
+
+To deploy the TypeScript version you just need to:
+
+```bash
+cd the-lambda-power-tuner
+npm run deploy
+```
+
+For Python deployment, see the instructions [here](https://github.com/cdk-patterns/serverless#2-download-pattern-in-python-or-typescript-cdk)
+
 
 ## How to execute the state machine (programmatically)
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,24 @@ $ pip install aws-sam-cli
 $ aws configure
 ```
 
-Now we can use [CDK Patterns](https://github.com/cdk-patterns/serverless) to give us a pre configured project in either TypeScript or Python:
+If you already have a CDK project you can include the following to use the [sam module](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-sam-readme.html):
+
+```typescript
+import sam = require('@aws-cdk/aws-sam');
+
+new sam.CfnApplication(this, 'powerTuner', {
+  location: {
+    applicationId: 'arn:aws:serverlessrepo:us-east-1:451282441545:applications/aws-lambda-power-tuning',
+    semanticVersion: '3.2.4'
+  },
+  parameters: {
+    "lambdaResource": "*",
+    "PowerValues": "128,256,512,1024,1536,3008"
+  }
+})
+```
+
+Alternatively you can use [CDK Patterns](https://github.com/cdk-patterns/serverless) to give us a pre configured project in either TypeScript or Python:
 
 ```bash
 # For the TypeScript CDK version
@@ -91,7 +108,6 @@ npm run deploy
 ```
 
 For Python deployment, see the instructions [here](https://github.com/cdk-patterns/serverless#2-download-pattern-in-python-or-typescript-cdk)
-
 
 ## How to execute the state machine (programmatically)
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ new sam.CfnApplication(this, 'powerTuner', {
 })
 ```
 
-Alternatively you can use [CDK Patterns](https://github.com/cdk-patterns/serverless) to give us a pre configured project in either TypeScript or Python:
+Alternatively you can use [CDK Patterns](https://github.com/cdk-patterns/serverless) to give you a pre configured project in either TypeScript or Python:
 
 ```bash
 # For the TypeScript CDK version


### PR DESCRIPTION
I have added into the readme the quickest way to deploy the power tuning state machine with AWS CDK.