### PR TITLE
Refactor SAM template to use AWS::Serverless::StateMachine

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -4,7 +4,7 @@ Transform: AWS::Serverless-2016-10-31
 Metadata:
   AWS::ServerlessRepo::Application:
     Name: aws-lambda-power-tuning
-    Description: "AWS Lambda Power Tuning is an open-source tool that can help you visualize and fine-tune the memory/power configuration of Lambda functions. It runs in your AWS account - powered by AWS Step Functions - and it supports multiple optimization strategies."
+    Description: AWS Lambda Power Tuning is an open-source tool that can help you visualize and fine-tune the memory/power configuration of Lambda functions. It runs in your AWS account - powered by AWS Step Functions - and it supports multiple optimization strategies.
     Author: Alex Casalboni
     SpdxLicenseId: Apache-2.0
     LicenseUrl: LICENSE.txt
@@ -134,94 +134,77 @@ Resources:
             Action: sts:AssumeRole
 
   powerTuningStateMachine:
-    Type: AWS::StepFunctions::StateMachine
+    Type: AWS::Serverless::StateMachine
     Properties:
-      RoleArn: !GetAtt statemachineRole.Arn
-      DefinitionString:
-        !Sub
-          - '
-            {
-              "Comment": "AWS Lambda Power Tuning state machine",
-              "StartAt": "Initializer",
-              "States": {
-                  "Initializer": {
-                      "Type": "Task",
-                      "Resource": "${initializerArn}",
-                      "Next": "Branching",
-                      "ResultPath": "$.powerValues",
-                      "Catch": [{
-                        "ErrorEquals": [ "States.ALL" ],
-                        "Next": "CleanUpOnError",
-                        "ResultPath": "$.error"
-                      }]
-                  },
-                  "Branching": {
-                      "Type": "Map",
-                      "Next": "Cleaner",
-                      "ItemsPath": "$.powerValues",
-                      "ResultPath": "$.stats",
-                      "Parameters": {
-                        "value.$": "$$.Map.Item.Value",
-                        "lambdaARN.$": "$.lambdaARN",
-                        "num.$": "$.num",
-                        "payload.$": "$.payload",
-                        "parallelInvocation.$": "$.parallelInvocation"
-                      },
-                      "MaxConcurrency": 0,
-                      "Catch": [{
-                        "ErrorEquals": ["States.ALL"],
-                        "Next": "CleanUpOnError",
-                        "ResultPath": "$.error"
-                      }],
-                      "Iterator": {
-                          "StartAt": "Executor",
-                          "States": {
-                              "Executor": {
-                                  "Type": "Task",
-                                  "Resource": "${executorArn}",
-                                  "End": true,
-                                  "Retry": [{
-                                      "ErrorEquals": ["States.ALL"],
-                                      "IntervalSeconds": 3,
-                                      "MaxAttempts": 2
-                                  }]
-                              }
-                          }
-                      }
-                  },
-                  "Cleaner": {
-                      "Type": "Task",
-                      "Next": "Analyzer",
-                      "ResultPath": null,
-                      "Resource": "${cleanerArn}"
-                  },
-                  "Analyzer": {
-                      "Type": "Task",
-                      "Resource": "${analyzerArn}",
-                      "ResultPath": "$.analysis",
-                      "Next": "Optimizer"
-                  },
-                  "Optimizer": {
-                      "Type": "Task",
-                      "Resource": "${optimizerArn}",
-                      "ResultPath": null,
-                      "OutputPath": "$.analysis",
-                      "End": true
-                  },
-                  "CleanUpOnError": {
-                      "Type": "Task",
-                      "ResultPath": null,
-                      "OutputPath": null,
-                      "Resource": "${cleanerArn}",
-                      "End": true
-                  }
-              }
-          }'
-          - initializerArn: !GetAtt initializer.Arn
-            executorArn: !GetAtt executor.Arn
-            cleanerArn: !GetAtt cleaner.Arn
-            analyzerArn: !GetAtt analyzer.Arn
-            optimizerArn: !GetAtt optimizer.Arn
+      Role: !GetAtt statemachineRole.Arn
+      Definition:
+        Comment: AWS Lambda Power Tuning state machine
+        StartAt: Initializer
+        States:
+
+          Initializer:
+            Type: Task
+            Resource: !GetAtt initializer.Arn
+            Next: Branching
+            ResultPath: $.powerValues
+            Catch:
+              - ErrorEquals: [ States.ALL ]
+                Next: CleanUpOnError
+                ResultPath: $.error
+
+          Branching:
+            Type: Map
+            Next: Cleaner
+            ItemsPath: $.powerValues
+            ResultPath: $.stats
+            Parameters:
+              value.$: $$.Map.Item.Value
+              lambdaARN.$: $.lambdaARN
+              num.$: $.num
+              payload.$: $.payload
+              parallelInvocation.$: $.parallelInvocation
+            MaxConcurrency: 0
+            Catch:
+              - ErrorEquals: [ States.ALL ]
+                Next: CleanUpOnError
+                ResultPath: $.error
+            Iterator:
+              StartAt: Executor
+              States:
+                Executor:
+                  Type: Task
+                  Resource: !GetAtt executor.Arn
+                  End: true
+                  Retry:
+                    - ErrorEquals: [ States.ALL ]
+                      IntervalSeconds: 3
+                      MaxAttempts: 2
+
+          Cleaner:
+            Type: Task
+            Resource: !GetAtt cleaner.Arn
+            Next: Analyzer
+            ResultPath: null
+
+          Analyzer:
+            Type: Task
+            Resource: !GetAtt analyzer.Arn
+            Next: Optimizer
+            ResultPath: $.analysis
+
+          Optimizer:
+            Type: Task
+            Resource: !GetAtt optimizer.Arn
+            ResultPath: null
+            OutputPath: $.analysis
+            End: true
+
+          CleanUpOnError:
+            Type: Task
+            ResultPath: null
+            OutputPath: null
+            Resource: !GetAtt cleaner.Arn
+            End: true
 
 Outputs:
   StateMachineARN:


### PR DESCRIPTION
Implements #89 🎉 

Interesting things to note:

- `RoleArn` becomes `Role`
- `DefinitionString` becomes `Definition` - I've decided to keep it inline to simplify the use of intrinsic functions (e.g. `Resource: !GetAtt executor.Arn`)