### PR TITLE
Bugfix: weighted payload allocation (uneven division)

### DIFF
--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -214,10 +214,7 @@ module.exports.invokeLambdaWithProcessors = async(lambdaARN, alias, payload, pre
  * Invoke a given Lambda Function:Alias with payload and return its logs.
  */
 module.exports.invokeLambda = (lambdaARN, alias, payload) => {
-    if (!alias) {
-        alias = '$LATEST';
-    }
-    console.log(`Invoking function ${lambdaARN}:${alias} with payload ${JSON.stringify(payload)}`);
+    console.log(`Invoking function ${lambdaARN}:${alias || '$LATEST'} with payload ${JSON.stringify(payload)}`);
     const params = {
         FunctionName: lambdaARN,
         Qualifier: alias,

--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -214,7 +214,10 @@ module.exports.invokeLambdaWithProcessors = async(lambdaARN, alias, payload, pre
  * Invoke a given Lambda Function:Alias with payload and return its logs.
  */
 module.exports.invokeLambda = (lambdaARN, alias, payload) => {
-    console.log(`Invoking function ${lambdaARN}:${alias || '$LATEST'} with payload ${JSON.stringify(payload)}`);
+    if (!alias) {
+        alias = '$LATEST';
+    }
+    console.log(`Invoking function ${lambdaARN}:${alias} with payload ${JSON.stringify(payload)}`);
     const params = {
         FunctionName: lambdaARN,
         Qualifier: alias,

--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -214,7 +214,7 @@ module.exports.invokeLambdaWithProcessors = async(lambdaARN, alias, payload, pre
  * Invoke a given Lambda Function:Alias with payload and return its logs.
  */
 module.exports.invokeLambda = (lambdaARN, alias, payload) => {
-    console.log(`Invoking function ${lambdaARN}:${alias || "$LATEST"} with payload ${JSON.stringify(payload)}`);
+    console.log(`Invoking function ${lambdaARN}:${alias || '$LATEST'} with payload ${JSON.stringify(payload)}`);
     const params = {
         FunctionName: lambdaARN,
         Qualifier: alias,
@@ -256,7 +256,7 @@ module.exports.generatePayloads = (num, payloadInput) => {
                 throw new Error('Invalid payload weight (num is too small)');
             }
             const howManyWillBeLeft = num - done - howMany;
-            if (howManyWillBeLeft > 0 && howManyWillBeLeft < howMany ) {
+            if (howManyWillBeLeft > 0 && howManyWillBeLeft < howMany) {
                 howMany += howManyWillBeLeft;
             }
             payloads.fill(utils.convertPayload(p.payload), done, done + howMany);

--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -255,10 +255,12 @@ module.exports.generatePayloads = (num, payloadInput) => {
             if (howMany < 1) {
                 throw new Error('Invalid payload weight (num is too small)');
             }
+            // if it's an uneven division, make sure the last item fills the remaining gap
             const howManyWillBeLeft = num - done - howMany;
             if (howManyWillBeLeft > 0 && howManyWillBeLeft < howMany) {
                 howMany += howManyWillBeLeft;
             }
+            // finally fill the list with howMany items
             payloads.fill(utils.convertPayload(p.payload), done, done + howMany);
             done += howMany;
         }

--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -225,6 +225,65 @@ module.exports.invokeLambda = (lambdaARN, alias, payload) => {
     return lambda.invoke(params).promise();
 };
 
+
+/**
+ * Generate a list of `num` payloads (repeated or weighted)
+ */
+module.exports.generatePayloads = (num, payloadInput) => {
+    if (Array.isArray(payloadInput)) {
+        // if array, generate a list of payloads based on weights
+
+        // fail if empty list or missing weight/payload
+        if (payloadInput.length === 0 || payloadInput.some(p => !p.weight || !p.payload)) {
+            throw new Error('Invalid weighted payload structure');
+        }
+
+        if (num < payloadInput.length) {
+            throw new Error(`You have ${payloadInput.length} payloads and only "num"=${num}. Please increase "num".`);
+        }
+
+        // we use relative weights (not %), so here we compute the total weight
+        const total = payloadInput.map(p => p.weight).reduce((a, b) => a + b, 0);
+
+        // generate an array of num items (to be filled)
+        const payloads = utils.range(num);
+
+        // iterate over weighted payloads and fill the array based on relative weight
+        let done = 0;
+        for (let p of payloadInput) {
+            var howMany = Math.floor(p.weight * num / total);
+            if (howMany < 1) {
+                throw new Error('Invalid payload weight (num is too small)');
+            }
+            const howManyWillBeLeft = num - done - howMany;
+            if (howManyWillBeLeft > 0 && howManyWillBeLeft < howMany ) {
+                howMany += howManyWillBeLeft;
+            }
+            payloads.fill(utils.convertPayload(p.payload), done, done + howMany);
+            done += howMany;
+        }
+
+        return payloads;
+    } else {
+        // if not an array, always use the same payload (still generate a list)
+        const payloads = utils.range(num);
+        payloads.fill(utils.convertPayload(payloadInput), 0, num);
+        return payloads;
+    }
+};
+
+/**
+ * Convert payload to string, if it's not a string already
+ */
+module.exports.convertPayload = (payload) => {
+    // optionally convert everything into string
+    if (typeof payload !== 'string' && typeof payload !== 'undefined') {
+        console.log('Converting payload to string from ', typeof payload);
+        payload = JSON.stringify(payload);
+    }
+    return payload;
+};
+
 /**
  * Compute average price and returns with average duration.
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-power-tuning",
-  "version": "3.2.5",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -304,12 +304,12 @@
       }
     },
     "aws-sdk": {
-      "version": "2.668.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.668.0.tgz",
-      "integrity": "sha512-mmZJmeenNM9hRR4k+JAStBhYFym2+VCPTRWv0Vn2oqqXIaIaNVdNf9xag/WMG8b8M80R3XXfVHKmDPST0/EfHA==",
+      "version": "2.697.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.697.0.tgz",
+      "integrity": "sha512-aNrwiPRHQyzjJxpfgLwVOevuGTOMkU5uiP4VDIngfc/k4s2kQgLSyhLSKmNTjbubHCHfs1sQQkP3RXK2Oi8Rbw==",
       "dev": true,
       "requires": {
-        "buffer": "4.9.1",
+        "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
         "jmespath": "0.15.0",
@@ -395,9 +395,9 @@
       "dev": true
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "aws-sdk": "^2.455.0",
-    "aws-sdk-mock": "^1.6.1",
+    "aws-sdk": "^2.697.0",
+    "aws-sdk-mock": "^1.7.0",
     "coveralls": "^3.0.3",
     "eslint": "^6.1.0",
     "eslint-config-strongloop": "^2.1.0",

--- a/test/unit/test-lambda.js
+++ b/test/unit/test-lambda.js
@@ -474,9 +474,9 @@ describe('Lambda Functions', async() => {
 
         it('should invoke the given cb, when done (weighted payload)', async() => {
             const weightedPayload = [
-                { name: 'A', payload: {test: 'A'}, weight: 10 },
-                { name: 'B', payload: {test: 'B'}, weight: 30 },
-                { name: 'C', payload: {test: 'C'}, weight: 60 },
+                { payload: {test: 'A'}, weight: 10 },
+                { payload: {test: 'B'}, weight: 30 },
+                { payload: {test: 'C'}, weight: 60 },
             ];
             await invokeForSuccess(handler, {
                 value: '128',
@@ -524,6 +524,28 @@ describe('Lambda Functions', async() => {
             expect(counters.A).to.be(10);
             expect(counters.B).to.be(30);
             expect(counters.C).to.be(60);
+        });
+
+        it('should invoke the given cb, when done (weighted payload 3)', async() => {
+            const weightedPayload = [
+                { payload: {test: 'A'}, weight: 1 },
+                { payload: {test: 'B'}, weight: 1 },
+                { payload: {test: 'C'}, weight: 1 },
+            ];
+            await invokeForSuccess(handler, {
+                value: '128',
+                input: {
+                    lambdaARN: 'arnOK',
+                    num: 10,
+                    payload: weightedPayload,
+                },
+            });
+
+            expect(invokeLambdaPayloads.length).to.be(10);
+            invokeLambdaPayloads.forEach(payload => {
+                expect(payload).to.be.a('string');
+            });
+
         });
 
         it('should explode if count(payloads) < num', async() => {

--- a/test/unit/test-utils.js
+++ b/test/unit/test-utils.js
@@ -330,6 +330,12 @@ describe('Lambda Utils', () => {
             invokeLambdaCounter = 0;
         });
 
+        it('should invoke the processing function without an alias', async() => {
+            const ARN = "arn:aws:lambda:eu-west-1:XXX:function:name";
+            const data = await utils.invokeLambdaProcessor(ARN, "{}");
+            expect(data).to.be(undefined); // mocked API call
+        });
+
         it('should invoke the processing function', async() => {
             sandBox.stub(utils, 'invokeLambda')
                 .callsFake(async() => {


### PR DESCRIPTION
Fix #97 

The bug wasn't covered by the test suite and it only happened in the case of an uneven division between `num` and `count(payloads)` (e.g. `num=100` and `count(payloads)=3`).

Solution: just make sure the array of generated payloads is filled until the end, using the last payload value.