### PR TITLE
Add NodeJS 13 and 14 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
   - 10.13
   - 11
   - 12
+  - 13
+  - 14
 install:
   # install Node.js dependencies
   - travis_retry npm ci


### PR DESCRIPTION
https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-runtimes-10-x-in-the-aws-sdk-for-javascript-v2/