### PR TITLE
Implement function update waiter (states expansion)

### DIFF
--- a/lambda/initializer.js
+++ b/lambda/initializer.js
@@ -16,7 +16,7 @@ module.exports.handler = async(event, context) => {
     // fetch initial $LATEST value so we can reset it later
     const initialPower = await utils.getLambdaPower(lambdaARN);
 
-    // reminder: configuration updates must run sequencially
+    // reminder: configuration updates must run sequentially
     // (otherwise you get a ResourceConflictException)
     for (let value of powerValues){
         const alias = 'RAM' + value;

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "aws-sdk": "^2.697.0",
-    "aws-sdk-mock": "^1.7.0",
+    "aws-sdk": "^2.945.0",
+    "aws-sdk-mock": "^5.2.1",
     "coveralls": "^3.0.3",
     "eslint": "^6.1.0",
     "eslint-config-strongloop": "^2.1.0",

--- a/template.yml
+++ b/template.yml
@@ -45,7 +45,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: nodejs12.x
+    Runtime: nodejs14.x
     MemorySize: 128
     Timeout: !Ref totalExecutionTimeout
     PermissionsBoundary: !If [UsePermissionsBoundary, !Ref permissionsBoundary, !Ref AWS::NoValue]

--- a/test/unit/test-utils.js
+++ b/test/unit/test-utils.js
@@ -22,13 +22,17 @@ const sandBox = sinon.createSandbox();
 
 // AWS SDK mocks
 AWS.mock('Lambda', 'getAlias', {});
-AWS.mock('Lambda', 'getFunctionConfiguration', {MemorySize: 1024});
+AWS.mock('Lambda', 'getFunctionConfiguration', {MemorySize: 1024, State: 'Active', LastUpdateStatus: 'Successful'});
 AWS.mock('Lambda', 'updateFunctionConfiguration', {});
 AWS.mock('Lambda', 'publishVersion', {});
 AWS.mock('Lambda', 'deleteFunction', {});
 AWS.mock('Lambda', 'createAlias', {});
 AWS.mock('Lambda', 'deleteAlias', {});
 AWS.mock('Lambda', 'invoke', {});
+
+// note: waiters aren't correctly mocked by aws-sdk-mock (for now)
+// https://github.com/dwyl/aws-sdk-mock/issues/173
+AWS.mock('Lambda', 'waitFor', {}); 
 
 describe('Lambda Utils', () => {
 
@@ -43,6 +47,7 @@ describe('Lambda Utils', () => {
         utils.deleteLambdaAlias,
         utils.invokeLambda,
         utils.invokeLambdaWithProcessors,
+        utils.waitForFunctionUpdate,
     ];
 
     // just returns the utility name for convenience
@@ -125,6 +130,15 @@ describe('Lambda Utils', () => {
             const aliasExists = await utils.verifyAliasExistance('arnOK', 'aliasName');
             expect(aliasExists).to.be(false);
         });
+    });
+
+    describe('waitForFunctionUpdate', () => {
+
+        it('should return if LastUpdateStatus is successful', async() => {
+            // TODO: remove waitFor mock and test this properly
+            await utils.waitForFunctionUpdate('arn:aws:lambda:us-east-1:XXX:function:YYY');
+        });
+
     });
 
     describe('extractDuration', () => {


### PR DESCRIPTION
Implements #134 

The initialize function now waits for the update to be completed with `lambda.waitFor('functionUpdated')` after invoking `lambda.updateFunctionConfiguration`.

It works for all functions (opt-in and opt-out).