### PR TITLE
Add explicit SDK dependency as Lambda Layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ serverless.yml
 
 .idea/
 .vscode/
+
+layer-sdk/src

--- a/README-DEPLOY.md
+++ b/README-DEPLOY.md
@@ -36,14 +36,20 @@ Now, you can clone this repository as follows:
 $ git clone https://github.com/alexcasalboni/aws-lambda-power-tuning.git
 ```
 
-Configure your deployment bucket name ([create one first!](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-bucket.html)) and stack name in the deployment script:
+Configure your deployment bucket name ([create one first!](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-bucket.html)) and stack name in `scripts/deploy.sh`:
 
 
 ```bash
 # config
 BUCKET_NAME=your-sam-templates-bucket
 STACK_NAME=lambda-power-tuning
-PowerValues='128,512,1024,1536,3008'
+# more config parameters are available too!
+```
+
+Build the SDK layer as follows:
+
+```bash
+$ bash scripts/build-layer.sh
 ```
 
 You can finally deploy the serverless app:

--- a/layer-sdk/build.sh
+++ b/layer-sdk/build.sh
@@ -1,4 +1,0 @@
-# cd here first!
-npm install --production
-mkdir -p ./src/nodejs
-mv ./node_modules ./src/nodejs

--- a/layer-sdk/build.sh
+++ b/layer-sdk/build.sh
@@ -1,0 +1,4 @@
+# cd here first!
+npm install --production
+mkdir -p ./src/nodejs
+mv ./node_modules ./src/nodejs

--- a/layer-sdk/package-lock.json
+++ b/layer-sdk/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "aws-sdk-layer",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aws-sdk": {
+      "version": "2.989.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.989.0.tgz",
+      "integrity": "sha512-sMjvqeF9mEOxXkhOAUjCrBt2iYafclkmaIbgSdjJ+te7zKXeReqrc6P3VgIGUxU8kwmdSro0n1NjrXbzKQJhcw==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/layer-sdk/package.json
+++ b/layer-sdk/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "aws-sdk-layer",
+  "version": "1.0.0",
+  "description": "A layer used by Lambda functions in this project.",
+  "author": "Alex Casalboni <alex@alexcasalboni.com>",
+  "licence": "MIT-0",
+  "scripts": {},
+  "dependencies": {
+    "aws-sdk": "^2.989.0"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -289,9 +289,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.945.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.945.0.tgz",
-      "integrity": "sha512-tkcoFAUol7c+9ZBnXsBTKfsj9bNckJ7uzj7FdD/a8AMt/6/18LlEISCiuHFl9qr8MItcON7UgnphJdFCTV7zBw==",
+      "version": "2.989.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.989.0.tgz",
+      "integrity": "sha512-sMjvqeF9mEOxXkhOAUjCrBt2iYafclkmaIbgSdjJ+te7zKXeReqrc6P3VgIGUxU8kwmdSro0n1NjrXbzKQJhcw==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "aws-sdk": "^2.945.0",
+    "aws-sdk": "^2.989.0",
     "aws-sdk-mock": "^5.2.1",
     "coveralls": "^3.0.3",
     "eslint": "^6.1.0",

--- a/scripts/build-layer.sh
+++ b/scripts/build-layer.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# make sure we're working on the layer folder
+cd layer-sdk
+
+# create subfolders
+## ./src is referenced by the LayerVersion resource (.gitignored)
+## ./src/nodejs will contain the node_modules
+mkdir -p ./src/nodejs
+
+# install layer dependencies (the SDK)
+npm i
+
+# clean up previous build ...
+rm -rf ./src/nodejs/node_modules
+
+# ... and move everything into the layer sub-folder
+mv ./node_modules ./src/nodejs

--- a/template.yml
+++ b/template.yml
@@ -59,11 +59,24 @@ Globals:
 
 Resources:
 
+  SDKlayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: AWS-SDK-v2_989_0
+      Description: AWS SDK 2.989.0
+      ContentUri: ./layer-sdk/src
+      CompatibleRuntimes:
+        - nodejs14.x
+      LicenseInfo: 'Available under the MIT-0 license.'
+      RetentionPolicy: Retain
+
   initializer:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: lambda
       Handler: initializer.handler
+      Layers:
+        - !Ref SDKlayer
       Policies:
         - AWSLambdaExecute # Managed Policy
         - Version: '2012-10-17' # Policy Document
@@ -83,6 +96,8 @@ Resources:
     Properties:
       CodeUri: lambda
       Handler: executor.handler
+      Layers:
+        - !Ref SDKlayer
       Policies:
         - AWSLambdaExecute # Managed Policy
         - Version: '2012-10-17' # Policy Document
@@ -97,6 +112,8 @@ Resources:
     Properties:
       CodeUri: lambda
       Handler: cleaner.handler
+      Layers:
+        - !Ref SDKlayer
       Policies:
         - AWSLambdaExecute # Managed Policy
         - Version: '2012-10-17' # Policy Document
@@ -122,6 +139,8 @@ Resources:
     Properties:
       CodeUri: lambda
       Handler: optimizer.handler
+      Layers:
+        - !Ref SDKlayer
       Policies:
         - AWSLambdaExecute # Managed Policy
         - Version: '2012-10-17' # Policy Document


### PR DESCRIPTION
This allows more granular control over the SDK versions in the future, to avoid unexpected incompatibilities and to support new services/features that aren't immediately available in the runtime SDK.