### PR TITLE
Add default architecture

### DIFF
--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -135,7 +135,7 @@ module.exports.getLambdaArchitecture = async(lambdaARN) => {
     const lambda = utils.lambdaClientFromARN(lambdaARN);
     const config = await lambda.getFunctionConfiguration(params).promise();
     if (typeof config.Architectures !== 'undefined') {
-         return config.Architectures[0];
+        return config.Architectures[0];
     };
     return 'x86_64';
 };

--- a/test/unit/test-utils.js
+++ b/test/unit/test-utils.js
@@ -364,6 +364,20 @@ describe('Lambda Utils', () => {
             const data = await utils.getLambdaArchitecture(ARN);
             expect(data).to.be('x86_64');
         });
+
+        it('should return arm64 when Graviton is supported', async() => {
+            AWS.remock('Lambda', 'getFunctionConfiguration', {MemorySize: 1024, State: 'Active', LastUpdateStatus: 'Successful', Architectures: ["arm64"]});
+            const ARN = 'arn:aws:lambda:eu-west-1:XXX:function:name';
+            const data = await utils.getLambdaArchitecture(ARN);
+            expect(data).to.be('arm64');
+        });
+
+        it('should always return x86_64 when Graviton is not supported', async() => {
+            AWS.remock('Lambda', 'getFunctionConfiguration', {MemorySize: 1024, State: 'Active', LastUpdateStatus: 'Successful'});
+            const ARN = 'arn:aws:lambda:eu-west-1:XXX:function:name';
+            const data = await utils.getLambdaArchitecture(ARN);
+            expect(data).to.be('x86_64');
+        });
     });
 
     describe('invokeLambdaProcessor', () => {


### PR DESCRIPTION
In regions where Graviton is not available yet (e.g. Paris), use x86 as default. Currently the function to get the Lambda's architecture fails since the property is not available in the configuration.