### PR TITLE
Sort durations numerically

### DIFF
--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -403,7 +403,7 @@ module.exports.computeAverageDuration = (durations) => {
 
     // compute trimmed mean (discard 20% of low/high values)
     const averageDuration = durations
-        .sort() // sort numerically
+        .sort(function (a, b) {  return a - b;  }) // sort numerically
         .slice(toBeDiscarded, -toBeDiscarded) // discard first/last values
         .reduce((a, b) => a + b, 0) // sum all together
         / newN

--- a/test/unit/test-utils.js
+++ b/test/unit/test-utils.js
@@ -209,7 +209,7 @@ describe('Lambda Utils', () => {
 
     describe('computeAverageDuration', () => {
         const durations = [
-            1, 1, 2, 3, 3,
+            1, 1, 2, 3, 2000
         ];
 
         it('should return the average duration', () => {


### PR DESCRIPTION
By default sort() is ordering items alphabetically. This was causing some unexpected results when comparing when some cold start durations where ignored for one configuration and preserved for another.