### PR TITLE
Resolving issue with region being passed into a module that doesn't expect it

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,4 @@
 module "power_tuning" {
   source     = "./module"
-  aws_region = var.aws_region
   account_id = var.account_id
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,3 @@
-variable "aws_region" {
-  default = "eu-west-1"
-}
-
 variable "account_id" {
-  default = "123456789101"
+  default = "411140388634"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,3 @@
 variable "account_id" {
-  default = "411140388634"
+  default = "123456789101"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,7 @@
+variable "aws_region" {
+  default = "eu-west-1"
+}
+
 variable "account_id" {
   default = "123456789101"
 }


### PR DESCRIPTION
It's been reported to me that the region is still set in the calling module but it's been removed from the main module. This PR fixes that issue