### PR TITLE
Add log groups with retention value

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -50,6 +50,10 @@ Parameters:
     Type: String
     Default: ''
     Description: Name of the SDK layer, if customization is needed (optional)
+  logGroupRetentionInDays:
+    Type: Number
+    Default: 7
+    Description: The number of days to retain the log events in the Lambda log groups.
 
 Conditions:
   UsePermissionsBoundary: !Not [!Equals [!Ref permissionsBoundary, '']]
@@ -85,6 +89,13 @@ Resources:
     Metadata:
       BuildMethod: nodejs14.x
 
+  initializerLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn: initializer
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${initializer}'
+      RetentionInDays: !Ref logGroupRetentionInDays
+
   initializer:
     Type: AWS::Serverless::Function
     Properties:
@@ -105,6 +116,13 @@ Resources:
                 - lambda:CreateAlias
                 - lambda:UpdateAlias
               Resource: !Ref lambdaResource
+
+  executorLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn: executor
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${executor}'
+      RetentionInDays: !Ref logGroupRetentionInDays
 
   executor:
     Type: AWS::Serverless::Function
@@ -143,6 +161,13 @@ Resources:
               - !Sub arn:${AWS::Partition}:s3:::${payloadS3Bucket}
               - !Sub arn:${AWS::Partition}:s3:::${payloadS3Bucket}/${payloadS3Key} # payloadS3Key is * by default
 
+  cleanerLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn: cleaner
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${cleaner}'
+      RetentionInDays: !Ref logGroupRetentionInDays
+
   cleaner:
     Type: AWS::Serverless::Function
     Properties:
@@ -161,6 +186,13 @@ Resources:
                 - lambda:DeleteFunction  # only by version/qualifier
               Resource: !Ref lambdaResource
 
+  analyzerLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn: analyzer
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${analyzer}'
+      RetentionInDays: !Ref logGroupRetentionInDays
+
   analyzer:
     Type: AWS::Serverless::Function
     Properties:
@@ -169,6 +201,13 @@ Resources:
       Timeout: 10
       Policies:
         - AWSLambdaBasicExecutionRole # only logs
+
+  optimizerLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn: optimizer
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${optimizer}'
+      RetentionInDays: !Ref logGroupRetentionInDays
 
   optimizer:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
This pull request is used to set a retention value for log groups (other than never expired).
Also, because log groups are defined as resources in CFN, tags from SAM are applied to log groups.