### PR TITLE
Add parameter to power-tune only cold starts

### DIFF
--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -25,7 +25,7 @@ module.exports.lambdaBaseCost = (region, architecture) => {
     return this.baseCostForRegion(priceMap, region);
 };
 
-module.exports.buildAliasString = (baseAlias, onlyColdStarts = false, index = 0) => {
+module.exports.buildAliasString = (baseAlias, onlyColdStarts, index) => {
     let alias = baseAlias;
     if (onlyColdStarts) {
         alias += `-${index}`;

--- a/test/unit/test-utils.js
+++ b/test/unit/test-utils.js
@@ -24,7 +24,13 @@ const sandBox = sinon.createSandbox();
 
 // AWS SDK mocks
 AWS.mock('Lambda', 'getAlias', {});
-AWS.mock('Lambda', 'getFunctionConfiguration', {MemorySize: 1024, State: 'Active', LastUpdateStatus: 'Successful', Architectures: ['x86_64']});
+AWS.mock('Lambda', 'getFunctionConfiguration', {
+    MemorySize: 1024,
+    State: 'Active',
+    LastUpdateStatus: 'Successful',
+    Architectures: ['x86_64'],
+    Environment: {Variables: {TEST: 'OK'}},
+});
 AWS.mock('Lambda', 'updateFunctionConfiguration', {});
 AWS.mock('Lambda', 'publishVersion', {});
 AWS.mock('Lambda', 'deleteFunction', {});
@@ -108,7 +114,8 @@ describe('Lambda Utils', () => {
     describe('getLambdaPower', () => {
         it('should return the memory value', async() => {
             const value = await utils.getLambdaPower('arn:aws:lambda:us-east-1:XXX:function:YYY');
-            expect(value).to.be(1024);
+            expect(value.power).to.be(1024);
+            expect(value.envVars.TEST).to.be('OK');
         });
     });
 

--- a/test/unit/test-utils.js
+++ b/test/unit/test-utils.js
@@ -112,10 +112,26 @@ describe('Lambda Utils', () => {
     });
 
     describe('getLambdaPower', () => {
-        it('should return the memory value', async() => {
+        it('should return the power value and env vars', async() => {
             const value = await utils.getLambdaPower('arn:aws:lambda:us-east-1:XXX:function:YYY');
             expect(value.power).to.be(1024);
+            expect(value.envVars).to.be.an('object');
             expect(value.envVars.TEST).to.be('OK');
+        });
+
+        it('should return the power value and env vars even when empty env', async() => {
+            AWS.remock('Lambda', 'getFunctionConfiguration', {
+                MemorySize: 1024,
+                State: 'Active',
+                LastUpdateStatus: 'Successful',
+                Architectures: ['x86_64'],
+                Environment: null, // this is null if no vars are set
+            });
+
+            const value = await utils.getLambdaPower('arn:aws:lambda:us-east-1:XXX:function:YYY');
+            expect(value.power).to.be(1024);
+            expect(value.envVars).to.be.an('object');
+            expect(value.envVars.TEST).to.be(undefined);
         });
     });
 


### PR DESCRIPTION
Implement #176 

Still a few tests to run, but it works :)

I have not encountered any quotas or rate limiting when creating new versions/aliases.

- With 5 power values and num=10, it successfully created 50 versions and aliases: the `initializer` completed in 88 seconds and the `cleaner` in 12 seconds 
- With 5 power values and num=50, it successfully created 250 versions and aliases: the `initializer` completed in 430 seconds and the `cleaner` in 53 seconds 

As expected, there's no major difference in the invocation time of the `executor` step, besides the cold start itself. The executor just needs to invoke the right aliases, either in series or in parallel.

Two notes:
1. It will be highly recommended to increase the `TotalExecutionTimeout` parameter at deploy time (it's 5 minutes by default and it applies to all functions). Given the maximum of 15min, there is an upperbound to the total number of aliases/versions that can be created (more or less 35 per minute, for a maximum of 500).
2. Most of the initialization time is spent on waiting on `UpdateFunctionConfiguration` (using an SDK waiter) and the current waiter delay is 500ms. I'll try to optimize this a bit, so we could increase the upperbound mentioned above.
