### PR TITLE
Allow GetFunctionConfiguration action for Optimizer function (autoOptimize)

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -240,6 +240,7 @@ Resources:
                 - lambda:GetAlias
                 - lambda:PublishVersion
                 - lambda:UpdateFunctionConfiguration
+                - lambda:GetFunctionConfiguration
                 - lambda:CreateAlias
                 - lambda:UpdateAlias
               Resource: !Ref lambdaResource

--- a/terraform/module/json_files/optimizer.json
+++ b/terraform/module/json_files/optimizer.json
@@ -7,6 +7,7 @@
                 "lambda:GetAlias",
                 "lambda:PublishVersion",
                 "lambda:UpdateFunctionConfiguration",
+                "lambda:GetFunctionConfiguration",
                 "lambda:CreateAlias",
                 "lambda:UpdateAlias"
             ],


### PR DESCRIPTION
Lack of this Action (`lambda:GetFunctionConfiguration`) doesn't allow to use `"autoOptimize": true` in CI pipeline. 

The Optimizer is not allowed to retrieve the Lambda config, and thus it can not change the Lambda parameters:
`
User: [serverlessrepo-aws-lambda-power-tuni-optimizerRole ARN] is not authorized to perform: lambda:GetFunctionConfiguration on resource: [lambda ARN] because no identity-based policy allows the lambda:GetFunctionConfiguration action
`

The error in Step Functions looks like this:
![image](https://github.com/alexcasalboni/aws-lambda-power-tuning/assets/32177337/7a266cd1-a815-4b44-b07a-5d3534a89d4c)
