### PR TITLE
Adds ability to use terraform module directly from GitHub repository

### DIFF
--- a/terraform/Readme.md
+++ b/terraform/Readme.md
@@ -3,11 +3,16 @@
 ## Overview
 This deployment option is intended for those who may not be in a position to use AWS Cloudformation, in cases where you do not have access or when CloudFormation is not an approved service within your company.
 
-The Terraform code is contained in the `terraform` directory of this project. All commands should be run from within this directory.
+The Terraform code is contained in the `terraform` directory of this project.
 
-## Before you start
+You can either clone this repository and run the terraform command from within the `terraform` directory.
+Another solution is to reference the git repository directly and include the module in another Terraform project.
 
-Modify the `variables.tf` file with your target AWS Account and region. 
+## Local repository
+
+### Before you start
+
+Modify the `variables.tf` file with your target AWS Account and region.
 ```
 variable "account_id" {
   default = "123456789101"
@@ -17,7 +22,7 @@ variable "aws_region" {
 }
 ```
 
-## Deploy the solution
+### Deploy the solution
 ```
 terraform init
 terraform plan
@@ -26,16 +31,28 @@ terraform apply
 
 Once deployed, follow [these instructions](../README-EXECUTE.md) to run Lambda Power Tuning.
 
-## Deploy to multiple accounts/regions
+### Deploy to multiple accounts/regions
 
 If you're planning on deploying to multiple accounts or regions, it's recommended to adopt a folder strategy by either account or region. This will make sure you keep your statefile lightweight and plans/applies faster.
 
-## Delete the solution
+### Delete the solution
 Run the below command to remove all resources from your account:
 ```bash
-terraform destroy 
+terraform destroy
 ```
 Enter 'yes' at the confirmation prompt.
+
+## Remote repository
+
+When using the module inside another Terraform project, you can reference the module directly from the GitHub repository.
+
+```hcl
+module "aws-lambda-power-tuning" {
+  source = "git@github.com:alexcasalboni/aws-lambda-power-tuning//terraform/module"
+
+  account_id = data.aws_caller_identity.current.account_id
+}
+```
 
 ## Versions tested
 - 0.13.3

--- a/terraform/module/data.tf
+++ b/terraform/module/data.tf
@@ -1,16 +1,17 @@
 resource "null_resource" "build_layer" {
   provisioner "local-exec" {
-    command     = "${path.module}/scripts/build-layer.sh"
+    command     = "./build-layer.sh"
     interpreter = ["bash"]
+    working_dir = "${path.module}/scripts/"
   }
   triggers = {
-    always_run = "${timestamp()}"
+    always_run = timestamp()
   }
 }
 
 data "archive_file" "layer" {
   type        = "zip"
-  source_dir  = "../layer-sdk/src/"
+  source_dir  = "${path.module}/../../layer-sdk/src/"
   output_path = "../src/layer.zip"
 
   depends_on = [
@@ -21,10 +22,9 @@ data "archive_file" "layer" {
 data "archive_file" "app" {
   type        = "zip"
   output_path = "../src/app.zip"
-  source_dir  = "../lambda/"
+  source_dir  = "${path.module}/../../lambda/"
 
   depends_on = [
     null_resource.build_layer
   ]
 }
-

--- a/terraform/module/lambda.tf
+++ b/terraform/module/lambda.tf
@@ -186,12 +186,11 @@ resource "aws_lambda_function" "optimizer" {
 
 
 resource "aws_lambda_layer_version" "lambda_layer" {
-  filename    = "../src/layer.zip"
-  layer_name  = "AWS-SDK-v3"
-  description = "AWS SDK 3"
+  filename                 = "../src/layer.zip"
+  layer_name               = "AWS-SDK-v3"
+  description              = "AWS SDK 3"
   compatible_architectures = ["x86_64"]
-  compatible_runtimes = ["nodejs20.x"]
+  compatible_runtimes      = ["nodejs20.x"]
 
   depends_on = [data.archive_file.layer]
 }
-

--- a/terraform/module/locals.tf
+++ b/terraform/module/locals.tf
@@ -1,7 +1,7 @@
 locals {
   defaultPowerValues = "[128,256,512,1024,1536,3008]"
   minRAM             = 128
-  baseCosts          = jsonencode({"x86_64": {"ap-east-1":2.9e-9,"af-south-1":2.8e-9,"me-south-1":2.6e-9,"eu-south-1":2.4e-9,"ap-northeast-3":2.7e-9,"default":2.1e-9}, "arm64": {"default":1.7e-9}})
+  baseCosts          = jsonencode({ "x86_64" : { "ap-east-1" : 2.9e-9, "af-south-1" : 2.8e-9, "me-south-1" : 2.6e-9, "eu-south-1" : 2.4e-9, "ap-northeast-3" : 2.7e-9, "default" : 2.1e-9 }, "arm64" : { "default" : 1.7e-9 } })
   sfCosts            = jsonencode({ "default" : 0.000025, "us-gov-west-1" : 0.00003, "ap-northeast-2" : 0.0000271, "eu-south-1" : 0.00002625, "af-south-1" : 0.00002975, "us-west-1" : 0.0000279, "eu-west-3" : 0.0000297, "ap-east-1" : 0.0000275, "me-south-1" : 0.0000275, "ap-south-1" : 0.0000285, "us-gov-east-1" : 0.00003, "sa-east-1" : 0.0000375 })
   visualizationURL   = "https://lambda-power-tuning.show/"
 

--- a/terraform/module/scripts/build-layer.sh
+++ b/terraform/module/scripts/build-layer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # make sure we're working on the layer folder
-cd ../layer-sdk
+cd ../../../layer-sdk
 
 # create subfolders
 ## ./src is referenced by the LayerVersion resource (.gitignored)

--- a/terraform/module/state_machine.tf
+++ b/terraform/module/state_machine.tf
@@ -1,7 +1,7 @@
 
 resource "aws_sfn_state_machine" "state-machine" {
   name_prefix = var.lambda_function_prefix
-  role_arn = aws_iam_role.sfn_role.arn
+  role_arn    = aws_iam_role.sfn_role.arn
 
   definition = local.state_machine
 }

--- a/terraform/module/variables.tf
+++ b/terraform/module/variables.tf
@@ -1,10 +1,12 @@
 variable "account_id" {
   description = "Your AWS account id."
+  type        = string
 }
 
 variable "lambda_function_prefix" {
-  default = "lambda_power_tuning"
+  default     = "lambda_power_tuning"
   description = "Prefix used for the names of Lambda functions, Step Functions state machines, IAM roles, and IAM policies."
+  type        = string
 }
 
 variable "role_path_override" {
@@ -16,6 +18,7 @@ variable "role_path_override" {
 variable "permissions_boundary" {
   default     = null
   description = "ARN of the policy that is used to set the permissions boundary for the role."
+  type        = string
 }
 
 variable "vpc_subnet_ids" {


### PR DESCRIPTION
When you use an existing terraform project and you want to include the aws-lambda-power-tuning you have to clone/download the repository and copy the files.

Another, easier solution is to directly reference the remote directory. For this, some paths has to be changed.
Now, both solutions will work.


Remote inclusion will look like:
```hcl
module "aws-lambda-power-tuning" {
  source = "git@github.com:alexcasalboni/aws-lambda-power-tuning//terraform/module"
  account_id = data.aws_caller_identity.current.account_id
}
```