### PR TITLE
fix(docs): update the typescript deploy commands

### DIFF
--- a/cdk/typescript/README.md
+++ b/cdk/typescript/README.md
@@ -20,4 +20,4 @@ See [here](../README.md).
  * `npm run build`   compile typescript to js
  * `npm run watch`   watch for changes and compile
  * `npm run test`    perform the jest unit tests
- * `npm run deploy`      deploy this stack to your default AWS account/region
+ * `npm run cdk deploy`      deploy this stack to your default AWS account/region


### PR DESCRIPTION
The typesscript readme instructions for deploying the stack seems to be missing a word