### PR TITLE
utils.extractDuration: improved json detection

### DIFF
--- a/lambda/utils.js
+++ b/lambda/utils.js
@@ -605,13 +605,27 @@ module.exports.computeAverageDuration = (durations, discardTopBottom) => {
 };
 
 /**
+ * Returns true if provided string is valid json, false otherwise
+ * @param str string to check
+ * @returns {boolean}
+ */
+module.exports.isValidJSON = (str) => {
+    try {
+        JSON.parse(str);
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
+
+/**
  * Extract duration (in ms) from a given Lambda's CloudWatch log.
  */
 module.exports.extractDuration = (log, durationType) => {
     if (!durationType){
         durationType = DURATIONS.durationMs; // default to `durationMs`
     }
-    if (log.charAt(0) === '{') {
+    if (utils.isValidJSON(log)) {
         // extract from JSON (multi-line)
         return utils.extractDurationFromJSON(log, durationType);
     } else {


### PR DESCRIPTION
the fact that log string checked by **extractDuration** function starts with curly bracket character does not mean this string is valid json. Because of this it is better to test via new function **isValidJSON** introduced in this PR.

The motivation behind this pull request is that we have seen executor lambda failures while testing our lambda. When investigating what is going on we found out the log captured by extractDurationFromJSON i not valid json that could be processed by current logic. See my comments and sample log data on issue [261](https://github.com/alexcasalboni/aws-lambda-power-tuning/issues/261).

using new json validation in this case enforces parsing by **extractDurationFromText**, not by **extractDurationFromJSON** which works in this case. 